### PR TITLE
Bump dev deps to newest incl. Pest 4 (PHPUnit 12)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,11 +41,11 @@ jobs:
           composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
-      - name: Execute tests
+      - name: Prepare PHPUnit config
         run: cp phpunit.xml.dist phpunit.xml
 
       - name: Execute tests
-        run: vendor/bin/pest
+        run: vendor/bin/pest --no-coverage
 
       - name: Store Log Artifacts
         if: failure()

--- a/composer.json
+++ b/composer.json
@@ -27,14 +27,14 @@
         "saloonphp/saloon": "^4.0"
     },
     "require-dev": {
-        "laravel/pint": "^1.21",
-        "larastan/larastan": "^3.9",
+        "laravel/pint": "^1.29",
+        "larastan/larastan": "^3.10",
         "orchestra/testbench": "^11.0",
-        "pestphp/pest": "^3.8",
+        "pestphp/pest": "^4.0",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
-        "spatie/laravel-ray": "^1.39"
+        "spatie/laravel-ray": "^1.43"
     },
     "autoload": {
         "psr-4": {
@@ -51,7 +51,7 @@
         "post-autoload-dump": "@composer run prepare",
         "prepare": "@php vendor/bin/testbench package:discover --ansi",
         "analyse": "vendor/bin/phpstan analyse",
-        "test": "vendor/bin/pest",
+        "test": "vendor/bin/pest --no-coverage",
         "test-coverage": "vendor/bin/pest --coverage",
         "format": "vendor/bin/pint"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" backupGlobals="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd" backupGlobals="false"
          bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false"
          executionOrder="random" failOnWarning="true" failOnRisky="true" failOnEmptyTestSuite="true"
          beStrictAboutOutputDuringTests="true" cacheDirectory=".phpunit.cache" backupStaticProperties="false">


### PR DESCRIPTION
- pestphp/pest ^3.8 -> ^4.0 (pulls PHPUnit 12, arch/mutate ^4 transitively)
- laravel/pint ^1.21 -> ^1.29, larastan ^3.9 -> ^3.10, laravel-ray ^1.39 -> ^1.43
- phpunit.xml.dist schema 10.3 -> 12.5
- Pest 4 / PHPUnit 12 now errors (not warns) when coverage reports are configured without a driver, so run the default suite with --no-coverage (CI + composer test); test-coverage still opts into coverage explicitly
- Rename duplicate "Execute tests" CI step to "Prepare PHPUnit config"

Runtime constraints unchanged: Saloon ^4.0 / laravel-plugin ^4.3 / cache-plugin ^3.1 (3.1.0 already bridges Saloon v4) were already correct.